### PR TITLE
Fix missing module telex

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv==1.0.1
 gunicorn==21.2.0
 python-dotenv==1.0.1
 pydantic==1.10.12
+telex


### PR DESCRIPTION
This pull request adds `telex` to the `requirements.txt` file to ensure it is installed as a required dependency. This update is necessary for proper functionality and compatibility with the project.  

**Changes Made:**  
- Added `telex` to `requirements.txt`  

**Why this change?**  
- Ensures `telex` is installed when setting up the project.  
- Prevents potential module import errors.  
- Maintains consistency in dependency management.  

**Testing:**  
- Ran `pip install -r requirements.txt` to verify successful installation.  
- Confirmed `telex` can be imported without issues.  

**Additional Notes:**  
- No breaking changes introduced.  
- Developers should run `pip install -r requirements.txt` after merging.  